### PR TITLE
feat: a link to the youtube channel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ const App = () => {
           <div className='action-btn-cont'>
             <a className='action-btn' referrerPolicy='no-referrer' href="https://www.twitch.tv/ufficio_informazioni" target='_blank'>Vai al Canale Twitch</a>
             <a className='action-btn' referrerPolicy='no-referrer' href="https://www.instagram.com/ufficioinformazioni/" target='_blank'>Seguici su Instagram</a>
+            <a className='action-btn' referrerPolicy='no-referrer' href="https://www.youtube.com/@ufficioinformazioni3220" target='_blank'>Seguici su YouTube</a>
             <a className='action-btn' referrerPolicy='no-referrer' href="https://t.me/+FOKLuWEMrBNhZDE0" target='_blank'>Entra nel Gruppo Telegram</a>
             <a className='action-btn' referrerPolicy='no-referrer' href="https://t.me/+XX6FANXm1fQxNmE8" target='_blank'>Entra nel Canale Telegram</a>
             <a className='action-btn' referrerPolicy='no-referrer' href="https://discord.gg/bJdy8GmJ74" target='_blank'>Entra nel Canale Discord</a>


### PR DESCRIPTION
During the last twitch live it was clear a link to the new youtube channel was needed, so add it to the "linktree"-style page.